### PR TITLE
docs: some suggestions

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -1,1 +1,1 @@
-/nix/store/sfa42fc13gsfpk1kh2h5xqgsigx0jy4s-cog.toml
+/nix/store/vf4y38mw45n3bknlnclvf7c79a8gbszr-cog.toml

--- a/src/configs/nixago_block.md
+++ b/src/configs/nixago_block.md
@@ -137,7 +137,7 @@ in
     };
   };
   # Prettier is a multi-language code formatter.
-  prettier = std.std.lib.mkNixago {
+  prettier = std.lib.dev.mkNixago {
     # We mainly use it here to format the Markdown in our README.
     configData = {
       printWidth = 80;

--- a/src/devshells/devshell_block.md
+++ b/src/devshells/devshell_block.md
@@ -55,8 +55,8 @@ to make fetching the latest version of the toolchain trivial.
 
 We've added two new cell blocks above: one of the `devshells` type and the other
 of the `functions` type. Our development shells will be defined in
-`/nix/cell/devshells.nix` and our toolchain will be defined in
-`/nix/cell/toolchain.nix`. The `devshells` type should be self-explanatory at
+`/nix/example/devshells.nix` and our toolchain will be defined in
+`/nix/example/toolchain.nix`. The `devshells` type should be self-explanatory at
 this point: this is where we will define the development shells available in our
 project. The `functions` type is a bit unique and serves as a general type for
 storing cell-specific Nix expressions. In this case, we're creating a

--- a/src/getting_started/first_block.md
+++ b/src/getting_started/first_block.md
@@ -7,7 +7,7 @@ defined any blocks.
 To resolve this, we'll create a new file: `./nix/example/apps.nix`.
 
 - `./nix/`: Defined in our `cellsFrom` argument in the `flake.nix`
-- `./example/`: The name of our cell.
+- `example/`: The name of our cell.
 - `apps.nix`: The name of our cell block.
 
 Hopefully, the `std` structure is starting to become natural now. Here are the
@@ -46,7 +46,7 @@ in
     version = "0.1.0";
 
     # `std` includes some useful helper functions, one of which is `incl` which
-    # handles filtering out unwanteed files from our package src. The benefit
+    # handles filtering out unwanted files from our package src. The benefit
     # here is it reduces unecessary builds by limiting the input files of our
     # derivation to only those that are needed to build it.
     src = std.incl (inputs.self) [
@@ -72,7 +72,7 @@ code. As is fairly typical with Nix, the file serves as one large function;
 however, the significance of the argument structure can be easily overlooked.
 This structure can be viewed as the _standardized_ form of all cell blocks. From
 these two arguments, it's possible to derive _all_ values required to perform
-our required logic.
+our logic.
 
 Again, this cannot be overstated: we define the arguments the same way each time
 and are guaranteed access to all of the tools and data required to perform our

--- a/src/getting_started/flake.md
+++ b/src/getting_started/flake.md
@@ -43,7 +43,7 @@ only the new additions will be commented.
         # This is one of the most important arguments for the `grow` function.
         # It defines the path where `std` will search for our cells. In this
         # case, we're specifying the `nix` subdirectory. A cell, in this case,
-        # would be defined in a subdirectory under `nix` (i.e. ./nix/cell).
+        # would be defined in a subdirectory under `nix` (e.g. ./nix/cell).
         cellsFrom = ./nix;
 
         # This is the second most important argument for the `grow` function. It
@@ -89,10 +89,10 @@ where we primarily derive the structure we discussed in the
 [previous chapter](introduction.md). Of note are the following:
 
 - `cellsFrom`: The cells that make up our _organism_ must be defined in a single
-  folder within our repository. It's idiomatic to name this folder either
-  `cells` or `nix`. Within this directory, each cell is isolated into a
-  subdirectory, with all of its cell blocks further nested under this
-  subdirectory.
+  folder within our repository. It's idiomatic to name this folder
+  esrc/getting_started/flake.mdither `cells` or `nix`. Within this directory,
+  each cell is isolated into a subdirectory, with all of its cell blocks further
+  nested under this subdirectory.
 - `cellBlock`: Each cell consists of one or more blocks which are defined here
   in list form. Recall that cell blocks are _typed_, and the general format for
   defining them is `(std.blockTypes.<type> "<name>")`; where `<type>` is a valid
@@ -104,7 +104,7 @@ code. We know where cells are defined, what block types are available, and where
 to find them. Determining where our _runnables_ exist is simply a matter of
 examining our `flake.nix` and following the paths accordingly.
 
-The `growOn` function takes a variadic number of additional arguments and is
+The `growOn` function takes a variable number of additional arguments and is
 what differentiates it from its [sibling function][grow] (`grow`). We will dive
 deeper into these additional arguments in a future chapter.
 


### PR DESCRIPTION
Thanks so much for the book.  Its great :)

I've made some superficial edits that may or may not be improvements/ correct. 

I also jotted down thoughts as I went which I'll dump below. 

My main suggestion would be to be much more explicit in sec 1.1 that I'm expected to be treating `./rust` as my proj_root, and adding the files.

I did get through all the chapters, just no notes past sec 2.1


--- 

### sec 1.1 

i.e --> e.g (unless all subdirs are called `cell/`

A function that takes a variable number of arguments is variadic.

### sec 1.2

I got to sec 1.2, and I'm not sure what I'm supposed to be doing.
Sec 1. says we'll adding stuff the rust project (linked and unambiguous), and invites you to clone it.
Sec 1.1 shows a flake... but the rust dir is a subdir of the project root which already has a flake,
and the docs flake isn't a subset/simplification of this.

Should I have treated the rust as 'organism' level and set it up as a new project  with a new flake?
Or its a cell, and I should edit the top level flake?
I think this will be clearer later, but i've flicked back and forth between these pages trying to work out if I missed something. [edit
:: it makes it clear that cargo files are at project root. ]

`./example/` makes me think its at proj root.

Suggestion: Please let me run the thing before digression

### sec 1.3

I had a bunch of issues.
Turned out I'd written `examples/` rather than `example/`.

### sec 1.4

I have an issue dropping into std shell
```
$nix shell github:divnix/std
error: cannot write modified lock file of flake 'github:divnix/std' (use '--no-write-lock-file' to ignore)
(use '--show-trace' to show detailed location information)

$nix shell github:divnix/std --no-write-lock-file
warning: not writing modified lock file of flake 'github:divnix/std':
• Updated input 'n2c/flake-utils':
    'github:numtide/flake-utils/1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1' (2022-05-30)
  → follows 'flake-utils'
```

### sec 2

### sec 2.1

devshell shows angry deprecation warning for `std.std.lib`.
