### PR TITLE
Add 'jq' to devshell

### DIFF
--- a/nix/std-book/devshells.nix
+++ b/nix/std-book/devshells.nix
@@ -18,6 +18,7 @@ l.mapAttrs (_: std.std.lib.mkShell) {
     ];
     packages = [
       nixpkgs.gh
+      nixpkgs.jq
       nixpkgs.mdbook
     ];
     commands = [


### PR DESCRIPTION
`jq` is used in https://jmgilman.github.io/std-book/getting_started/growing.html but not explicitly added to the devshell.